### PR TITLE
Fix filename case in #include directives

### DIFF
--- a/src/ArticulatedQuadrilateral2D.h
+++ b/src/ArticulatedQuadrilateral2D.h
@@ -12,7 +12,7 @@ Unless required by applicable law or agreed to in writing, software distributed 
 #define _ARTICULATEDQUADRILATERAL_h
 
 #if defined(ARDUINO) && ARDUINO >= 100
-	#include "arduino.h"
+	#include "Arduino.h"
 #else
 	#include "WProgram.h"
 #endif

--- a/src/ArticulatedQuadrilateral3D.h
+++ b/src/ArticulatedQuadrilateral3D.h
@@ -11,7 +11,7 @@ Unless required by applicable law or agreed to in writing, software distributed 
 #define _ARTICULATEDQUADRILATERAL3D_h
 
 #if defined(ARDUINO) && ARDUINO >= 100
-	#include "arduino.h"
+	#include "Arduino.h"
 #else
 	#include "WProgram.h"
 #endif

--- a/src/ArticulatedTriangle2D.h
+++ b/src/ArticulatedTriangle2D.h
@@ -11,7 +11,7 @@ Unless required by applicable law or agreed to in writing, software distributed 
 #define _ARTICULATEDTRIANGLE_h
 
 #if defined(ARDUINO) && ARDUINO >= 100
-	#include "arduino.h"
+	#include "Arduino.h"
 #else
 	#include "WProgram.h"
 #endif

--- a/src/ArticulatedTriangle3D.h
+++ b/src/ArticulatedTriangle3D.h
@@ -11,7 +11,7 @@ Unless required by applicable law or agreed to in writing, software distributed 
 #define _ARTICULATEDTRIANGLE3D_h
 
 #if defined(ARDUINO) && ARDUINO >= 100
-	#include "arduino.h"
+	#include "Arduino.h"
 #else
 	#include "WProgram.h"
 #endif

--- a/src/Point2D.h
+++ b/src/Point2D.h
@@ -11,7 +11,7 @@ Unless required by applicable law or agreed to in writing, software distributed 
 #define _POINT2D_h
 
 #if defined(ARDUINO) && ARDUINO >= 100
-	#include "arduino.h"
+	#include "Arduino.h"
 #else
 	#include "WProgram.h"
 #endif

--- a/src/Point3D.h
+++ b/src/Point3D.h
@@ -11,7 +11,7 @@ Unless required by applicable law or agreed to in writing, software distributed 
 #define _POINT3D_h
 
 #if defined(ARDUINO) && ARDUINO >= 100
-	#include "arduino.h"
+	#include "Arduino.h"
 #else
 	#include "WProgram.h"
 #endif

--- a/src/TrigUtils.h
+++ b/src/TrigUtils.h
@@ -11,7 +11,7 @@ Unless required by applicable law or agreed to in writing, software distributed 
 #define _TRIGUTILS_h
 
 #if defined(ARDUINO) && ARDUINO >= 100
-	#include "arduino.h"
+	#include "Arduino.h"
 #else
 	#include "WProgram.h"
 #endif


### PR DESCRIPTION
Incorrect capitalization of Arduino.h caused compilation to fail on filename case-sensitive operating systems like Linux.